### PR TITLE
Fix ANR on DWSynchronousMethodsNT.runInNewThread

### DIFF
--- a/datawedgeprofileintentswrapper/src/main/java/com/zebra/datawedgeprofileintents/DWSynchronousMethodsNT.java
+++ b/datawedgeprofileintentswrapper/src/main/java/com/zebra/datawedgeprofileintents/DWSynchronousMethodsNT.java
@@ -36,7 +36,7 @@ public class DWSynchronousMethodsNT {
         private Context mContext;
         public Pair<DWSynchronousMethods.EResults, String> mResults = null;
         public boolean mHasFinished = false;
-        private int ExecutionTimeoutMs = 3 * 1000;
+        private int mExecutionTimeoutMs = 3 * 1000;
 
 
         public SynchronousNTRunnable(Context context, String methodName, Object param, Class<?> paramClass)
@@ -102,8 +102,8 @@ public class DWSynchronousMethodsNT {
 
                 // However, ANR still occurs. Notably on TC52X. So we add a timeout.
                 totalElapsedMs += mSleepTimer;
-                if (totalElapsedMs > synchronousNTRunnable.ExecutionTimeoutMs)
-                    throw new TimeoutException("Unable to get thread result in " + synchronousNTRunnable.ExecutionTimeoutMs + "ms");
+                if (totalElapsedMs > synchronousNTRunnable.mExecutionTimeoutMs)
+                    throw new TimeoutException("Unable to get thread result in " + synchronousNTRunnable.mExecutionTimeoutMs + "ms");
 
             } catch (InterruptedException e) {
                 // Ré-interruption to current thread if InterruptedException

--- a/datawedgeprofileintentswrapper/src/main/java/com/zebra/datawedgeprofileintents/DWSynchronousMethodsNT.java
+++ b/datawedgeprofileintentswrapper/src/main/java/com/zebra/datawedgeprofileintents/DWSynchronousMethodsNT.java
@@ -65,10 +65,10 @@ public class DWSynchronousMethodsNT {
                 mHasFinished = true;
                 
             } catch (Exception e) {
+                e.printStackTrace();
+            } finally {
                 // Even if an error occurs, we must terminate the action to avoid waiting an infinite loop
                 mHasFinished = true;
-
-                e.printStackTrace();
             }
         }
     }

--- a/datawedgeprofileintentswrapper/src/main/java/com/zebra/datawedgeprofileintents/DWSynchronousMethodsNT.java
+++ b/datawedgeprofileintentswrapper/src/main/java/com/zebra/datawedgeprofileintents/DWSynchronousMethodsNT.java
@@ -62,7 +62,6 @@ public class DWSynchronousMethodsNT {
                 }
                 else
                     mResults = null;
-                mHasFinished = true;
                 
             } catch (Exception e) {
                 e.printStackTrace();

--- a/datawedgeprofileintentswrapper/src/main/java/com/zebra/datawedgeprofileintents/DWSynchronousMethodsNT.java
+++ b/datawedgeprofileintentswrapper/src/main/java/com/zebra/datawedgeprofileintents/DWSynchronousMethodsNT.java
@@ -123,7 +123,7 @@ public class DWSynchronousMethodsNT {
             }
         }
 
-        if (synchronizedThread.isAlive()) // Cas du timeout, on tue le thread
+        if (synchronizedThread.isAlive()) // In case of timeout : stop the thread
             synchronizedThread.interrupt();
 
         return synchronousNTRunnable.mResults;


### PR DESCRIPTION
Avoid infinite loop on DWSynchronousMethodsNT.runInNewThread by :
- Adding timeout to synchronousNTRunnable execution ;
- Avoid  mHasFinished = false when synchronousNTRunnable ends after unhandled exception